### PR TITLE
Use mounted cache when installing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # Copy the rest
 COPY . .
 # Build (install) the actual binaries
-RUN cargo install --path .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/src/app/target \
+    cargo install --path .
 
 # Runtime image
 FROM debian:bullseye-slim


### PR DESCRIPTION
## Problem
Trying to iteratively deploy using this template is a bit of a pain because dependencies need to be re-fetched each time the image is built. I was seeing times of about 3 minutes for my small rust project.

## Solution
I think this "completes" the caching that was being attempted in the `cargo build` command. The build creates the cache in `/usr/local/cargo/registry` and `/usr/src/app/target` but I noticed the install command wasn't taking advantage of this cache.

## How this was tested
I collected some timings on my machine with and without this change. I ran `DOCKER_BUILDKIT=1 docker build .` to build the docker image (no fly deploy):

Base case (no change)
```
DOCKER_BUILDKIT=1 docker build .
[+] Building 250.8s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                          0.0s
 => => transferring dockerfile: 896B                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                             0.0s
 => => transferring context: 47B                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/debian:bullseye-slim                                                                       0.4s
 => [internal] load metadata for docker.io/library/rust:latest                                                                                0.0s
 => [builder 1/8] FROM docker.io/library/rust:latest                                                                                          0.0s
 => [internal] load build context                                                                                                             0.1s
 => => transferring context: 77.63kB                                                                                                          0.0s
 => [stage-1 1/4] FROM docker.io/library/debian:bullseye-slim@sha256:a42bb0c298cc798f1d3a6c3ee942c54db6919373c88250255ff66aed2fdb7e41         0.1s
 => => resolve docker.io/library/debian:bullseye-slim@sha256:a42bb0c298cc798f1d3a6c3ee942c54db6919373c88250255ff66aed2fdb7e41                 0.0s
 => => sha256:a42bb0c298cc798f1d3a6c3ee942c54db6919373c88250255ff66aed2fdb7e41 1.85kB / 1.85kB                                                0.0s
 => => sha256:df172d92d287ec4d4a538e5db8026fcde5f91f5f90061423d69d6148ff05cc47 529B / 529B                                                    0.0s
 => => sha256:5a6a266925787b7ec18e22db41fb5bd00ac2b8a10b93d5210c72e7c3a5da0a45 1.46kB / 1.46kB                                                0.0s
 => [builder 2/8] RUN USER=root cargo new app                                                                                                 1.1s
 => [stage-1 2/4] RUN useradd -ms /bin/bash app                                                                                               0.4s
 => [stage-1 3/4] WORKDIR /app                                                                                                                0.0s
 => [builder 3/8] WORKDIR /usr/src/app                                                                                                        0.0s
 => [builder 4/8] COPY Cargo.toml Cargo.lock ./                                                                                               0.0s
 => [builder 5/8] RUN mkdir src && echo "fn main(){}" > src/main.rs                                                                           0.4s
 => [builder 6/8] RUN --mount=type=cache,target=/usr/local/cargo/registry     --mount=type=cache,target=/usr/src/app/target     cargo buil  118.6s
 => [builder 7/8] COPY . .                                                                                                                    0.1s
 => [builder 8/8] RUN cargo install --path .                                                                                                129.9s
 => [stage-1 4/4] COPY --from=builder /usr/local/cargo/bin/hello /app/hello                                                                   0.1s
 => exporting to image                                                                                                                        0.1s
 => => exporting layers                                                                                                                       0.1s
 => => writing image sha256:4d48ee9b63f515fea2e23518ac0ecdd26fd3411a0ee57b98985e478229eff33c                                                  0.0s
```

Re-build
```
DOCKER_BUILDKIT=1 docker build .
[+] Building 139.8s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                          0.0s
 => => transferring dockerfile: 38B                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                             0.0s
 => => transferring context: 34B                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/debian:bullseye-slim                                                                       0.4s
 => [internal] load metadata for docker.io/library/rust:latest                                                                                0.0s
 => [builder 1/8] FROM docker.io/library/rust:latest                                                                                          0.0s
 => [stage-1 1/4] FROM docker.io/library/debian:bullseye-slim@sha256:a42bb0c298cc798f1d3a6c3ee942c54db6919373c88250255ff66aed2fdb7e41         0.0s
 => [internal] load build context                                                                                                             0.0s
 => => transferring context: 4.06kB                                                                                                           0.0s
 => CACHED [builder 2/8] RUN USER=root cargo new app                                                                                          0.0s
 => CACHED [builder 3/8] WORKDIR /usr/src/app                                                                                                 0.0s
 => CACHED [builder 4/8] COPY Cargo.toml Cargo.lock ./                                                                                        0.0s
 => CACHED [builder 5/8] RUN mkdir src && echo "fn main(){}" > src/main.rs                                                                    0.0s
 => CACHED [builder 6/8] RUN --mount=type=cache,target=/usr/local/cargo/registry     --mount=type=cache,target=/usr/src/app/target     cargo  0.0s
 => [builder 7/8] COPY . .                                                                                                                    0.1s
 => [builder 8/8] RUN cargo install --path .                                                                                                139.1s
 => CACHED [stage-1 2/4] RUN useradd -ms /bin/bash app                                                                                        0.0s
 => CACHED [stage-1 3/4] WORKDIR /app                                                                                                         0.0s
 => [stage-1 4/4] COPY --from=builder /usr/local/cargo/bin/hello /app/hello                                                                   0.1s
 => exporting to image                                                                                                                        0.1s
 => => exporting layers                                                                                                                       0.1s
 => => writing image sha256:85f06542fb9e8812fe9914a942e86f57f87f3a54766742ed3ee0f2bd5b19ac06
```
 
**Now with the change after deleting the caches with `docker builder prune --filter type=exec.cachemount && docker system prune --volumes`**

Base case
```
DOCKER_BUILDKIT=1 docker build .
[+] Building 157.8s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                          0.0s
 => => transferring dockerfile: 1.01kB                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                             0.0s
 => => transferring context: 47B                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/debian:bullseye-slim                                                                       0.7s
 => [internal] load metadata for docker.io/library/rust:latest                                                                                0.0s
 => [builder 1/8] FROM docker.io/library/rust:latest                                                                                          0.0s
 => [stage-1 1/4] FROM docker.io/library/debian:bullseye-slim@sha256:a42bb0c298cc798f1d3a6c3ee942c54db6919373c88250255ff66aed2fdb7e41         0.1s
 => => resolve docker.io/library/debian:bullseye-slim@sha256:a42bb0c298cc798f1d3a6c3ee942c54db6919373c88250255ff66aed2fdb7e41                 0.0s
 => => sha256:a42bb0c298cc798f1d3a6c3ee942c54db6919373c88250255ff66aed2fdb7e41 1.85kB / 1.85kB                                                0.0s
 => => sha256:df172d92d287ec4d4a538e5db8026fcde5f91f5f90061423d69d6148ff05cc47 529B / 529B                                                    0.0s
 => => sha256:5a6a266925787b7ec18e22db41fb5bd00ac2b8a10b93d5210c72e7c3a5da0a45 1.46kB / 1.46kB                                                0.0s
 => [internal] load build context                                                                                                             0.1s
 => => transferring context: 77.69kB                                                                                                          0.0s
 => [builder 2/8] RUN USER=root cargo new app                                                                                                 1.1s
 => [stage-1 2/4] RUN useradd -ms /bin/bash app                                                                                               0.5s
 => [stage-1 3/4] WORKDIR /app                                                                                                                0.0s
 => [builder 3/8] WORKDIR /usr/src/app                                                                                                        0.0s
 => [builder 4/8] COPY Cargo.toml Cargo.lock ./                                                                                               0.0s
 => [builder 5/8] RUN mkdir src && echo "fn main(){}" > src/main.rs                                                                           0.4s
 => [builder 6/8] RUN --mount=type=cache,target=/usr/local/cargo/registry     --mount=type=cache,target=/usr/src/app/target     cargo buil  125.0s
 => [builder 7/8] COPY . .                                                                                                                    0.1s
 => [builder 8/8] RUN --mount=type=cache,target=/usr/local/cargo/registry     --mount=type=cache,target=/usr/src/app/target     cargo insta  30.1s
 => [stage-1 4/4] COPY --from=builder /usr/local/cargo/bin/hello /app/hello                                                                   0.1s
 => exporting to image                                                                                                                        0.1s
 => => exporting layers                                                                                                                       0.1s
 => => writing image sha256:a7ae8c76c2315a3d6b476056e94d0d00ced1dffa1c735222665ecd8cb5dc5f7
```

Rebuild
```
DOCKER_BUILDKIT=1 docker build .
[+] Building 4.6s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                          0.0s
 => => transferring dockerfile: 38B                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                             0.0s
 => => transferring context: 34B                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/debian:bullseye-slim                                                                       0.4s
 => [internal] load metadata for docker.io/library/rust:latest                                                                                0.0s
 => [builder 1/8] FROM docker.io/library/rust:latest                                                                                          0.0s
 => [internal] load build context                                                                                                             0.0s
 => => transferring context: 3.33kB                                                                                                           0.0s
 => [stage-1 1/4] FROM docker.io/library/debian:bullseye-slim@sha256:a42bb0c298cc798f1d3a6c3ee942c54db6919373c88250255ff66aed2fdb7e41         0.0s
 => CACHED [builder 2/8] RUN USER=root cargo new app                                                                                          0.0s
 => CACHED [builder 3/8] WORKDIR /usr/src/app                                                                                                 0.0s
 => CACHED [builder 4/8] COPY Cargo.toml Cargo.lock ./                                                                                        0.0s
 => CACHED [builder 5/8] RUN mkdir src && echo "fn main(){}" > src/main.rs                                                                    0.0s
 => CACHED [builder 6/8] RUN --mount=type=cache,target=/usr/local/cargo/registry     --mount=type=cache,target=/usr/src/app/target     cargo  0.0s
 => [builder 7/8] COPY . .                                                                                                                    0.1s
 => [builder 8/8] RUN --mount=type=cache,target=/usr/local/cargo/registry     --mount=type=cache,target=/usr/src/app/target     cargo instal  3.9s
 => CACHED [stage-1 2/4] RUN useradd -ms /bin/bash app                                                                                        0.0s
 => CACHED [stage-1 3/4] WORKDIR /app                                                                                                         0.0s
 => [stage-1 4/4] COPY --from=builder /usr/local/cargo/bin/hello /app/hello                                                                   0.0s
 => exporting to image                                                                                                                        0.1s
 => => exporting layers                                                                                                                       0.1s
 => => writing image sha256:7e3bc161deabca94e5771085a41e714f7b692ddaa77858d4b60322639476d1d3
```

Each Rebuild had a single-line change in main.rs just to make sure the whole dockerfile build wasn't cached. This was the line I kept toggling back and forth:
```diff
diff --git a/src/main.rs b/src/main.rs
index 3b35ea7..8e37772 100644
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use warp::Filter;
 #[tokio::main]
 async fn main() {
     // Match any request and return hello world!
-    let routes = warp::any().map(|| "Hello, World!");
+    let routes = warp::any().map(|| "Hello, Rust!");
 
     warp::serve(routes)
         // ipv6 + ipv6 any addr

```

Hopefully this long-winded description speaks for itself but let me know if you have any concerns. It's definitely possible that I'm missing an obvious reason that this cache isn't used for the install command :sweat_smile: 