### PR TITLE
simplify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,11 @@
 FROM rust:latest as builder
 
-# Make a fake Rust app to keep a cached layer of compiled crates
-RUN USER=root cargo new app
 WORKDIR /usr/src/app
-COPY Cargo.toml Cargo.lock ./
-# Needs at least a main.rs file with a main function
-RUN mkdir src && echo "fn main(){}" > src/main.rs
-# Will build all dependent crates in release mode
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/src/app/target \
-    cargo build --release
-
-# Copy the rest
 COPY . .
-# Build (install) the actual binaries
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/src/app/target \
-    cargo install --path .
+# Will build and cache the binary and dependent crates in release mode
+RUN --mount=type=cache,target=/usr/local/cargo,from=rust:latest,source=/usr/local/cargo \
+    --mount=type=cache,target=target \
+    cargo build --release && mv ./target/release/hello ./hello
 
 # Runtime image
 FROM debian:bullseye-slim
@@ -28,6 +17,6 @@ USER app
 WORKDIR /app
 
 # Get compiled binaries from builder's cargo install directory
-COPY --from=builder /usr/local/cargo/bin/hello /app/hello
+COPY --from=builder /usr/src/app/hello /app/hello
 
 # No CMD or ENTRYPOINT, see fly.toml with `cmd` override.


### PR DESCRIPTION
This should remove the extra step of creating a fake Rust app.