### PR TITLE
Use bookworm-compatible rust & debian images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest as builder
+FROM rust:1-bookworm as builder
 
 WORKDIR /usr/src/app
 COPY . .
@@ -8,7 +8,7 @@ RUN --mount=type=cache,target=/usr/local/cargo,from=rust:latest,source=/usr/loca
     cargo build --release && mv ./target/release/hello ./hello
 
 # Runtime image
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 # Run as "app" user
 RUN useradd -ms /bin/bash app


### PR DESCRIPTION
To keep the GLIBC version compatible, I opted to fix the build image to bookworm (`rust:bookworm`), and to specify `debian:bookworm-slim` as the runtime image.

I chose `bookworm` as a compromise between something evergreen like `latest` and something that would be consistent between the rust and debian docker image repositories.

I'm happy to make changes to any of this if there are concerns or nuances I'm not aware of.  

Test-deployed at https://fly.io/apps/kzsh-hello-rust -> https://kzsh-hello-rust.fly.dev/
![2024-01-15T04:06:58+00:00](https://github.com/fly-apps/hello-rust/assets/1041312/61e42f4f-a0f1-4a73-8850-46840b6b027b)
![2024-01-15T04:07:28+00:00](https://github.com/fly-apps/hello-rust/assets/1041312/561ba565-bc86-43af-bf53-7b6b136ccebe)
